### PR TITLE
KKS fix

### DIFF
--- a/Core_BetterSquirt/BetterSquirt.cs
+++ b/Core_BetterSquirt/BetterSquirt.cs
@@ -40,6 +40,7 @@ namespace KK_BetterSquirt
 		internal static ConfigEntry<bool> Cfg_SquirtHD { get; private set; }
 		internal static ConfigEntry<Behavior> Cfg_Duration { get; private set; }
 		internal static ConfigEntry<Behavior> Cfg_Amount { get; private set; }
+		internal static ConfigEntry<float> Cfg_Angle { get; private set; }
 
 		private void Awake()
 		{
@@ -87,7 +88,12 @@ namespace KK_BetterSquirt
 				"Amount and volume of the improved squirting when triggered manually by the hotkey" +
 				"\n\nIn auto mode it depends on the girl's excitement gauge");
 
-
+			Cfg_Angle = Config.Bind(
+				section: "",
+				key: "Angle",
+				defaultValue: 60f,
+				new ConfigDescription("Angle",
+					new AcceptableValueRange<float>(45f, 90f)));
 
 			GameAPI.RegisterExtraBehaviour<BetterSquirtController>(GUID);
 			var harmonyInstance = Harmony.CreateAndPatchAll(typeof(BetterSquirtController.Hooks), GUID);

--- a/Core_BetterSquirt/BetterSquirtController.cs
+++ b/Core_BetterSquirt/BetterSquirtController.cs
@@ -138,7 +138,7 @@ namespace KK_BetterSquirt
 				newGameObject.transform.SetParent(attachPointList[i].transform);
 #endif
 				//Adjust the position and rotation of the new Particle System to make sure the stream comes out of the manko at the right place and the right angle
-				//newGameObject.transform.localPosition = Vector3.zero;
+				newGameObject.transform.localPosition = Vector3.zero;
 				newGameObject.transform.localRotation = Quaternion.Euler(new Vector3(Cfg_Angle.Value, 0f, 0f));
 				newGameObject.transform.localScale = Vector3.one;
 

--- a/Core_BetterSquirt/BetterSquirtController.cs
+++ b/Core_BetterSquirt/BetterSquirtController.cs
@@ -85,8 +85,12 @@ namespace KK_BetterSquirt
 			HVoiceCtrl hVoiceCtrl = procTraverse.Field("voice").GetValue<HVoiceCtrl>();
 			GameObject asset = GetParticleAsset();
 
+			
+
 			//Get vanilla ParticleSystems that are not null, so theoretically there would be one ParticleSystem per female.
 			//"particle" corresponds to the first female, and "particle1" corresponds to the second female if she exists
+			// It does not correspond in KKS. All points at 0 index girl.
+
 			string[] particleFields = { "particle", "particle1" };
 			List<ParticleSystem> vanillaParticles = particleFields
 				.Select(field => procTraverse.Field(field).GetValue<HParticleCtrl>())
@@ -105,8 +109,20 @@ namespace KK_BetterSquirt
 			else
 				handCtrls = procTraverse.Field("vrHands").GetValue<MonoBehaviour[]>().ToList();
 
+			var charas = procTraverse.Field("lstFemale").GetValue<List<ChaControl>>();
+			var attachPointList = new List<Transform>();
+			foreach (var chara in charas)
+			{
+				var attachPoint = chara.objBodyBone.transform.Find("cf_n_height/cf_j_hips/cf_j_waist01/cf_j_waist02/cf_d_kokan/cf_j_kokan/cf_n_pee");
+				attachPoint.localPosition = new Vector3(0f, -0.01f, -0.01f);
+				attachPointList.Add(attachPoint);
+			}
 
+#if KK
 			for (int i = 0; i < vanillaParticles.Count; i++)
+#else
+			for (int i = 0; i < attachPointList.Count; i++)
+#endif
 			{
 				if (vanillaParticles[i] == null || handCtrls[i] == null)
 				{
@@ -116,10 +132,14 @@ namespace KK_BetterSquirt
 
 				GameObject newGameObject = Instantiate(asset);
 				newGameObject.name = asset.name;
+#if KK
 				newGameObject.transform.SetParent(vanillaParticles[i].transform.parent);
+#else
+				newGameObject.transform.SetParent(attachPointList[i].transform);
+#endif
 				//Adjust the position and rotation of the new Particle System to make sure the stream comes out of the manko at the right place and the right angle
-				newGameObject.transform.localPosition = new Vector3(-0.01f, 0f, 0f);
-				newGameObject.transform.localRotation = Quaternion.Euler(new Vector3(60f, 0, 0f));
+				//newGameObject.transform.localPosition = Vector3.zero;
+				newGameObject.transform.localRotation = Quaternion.Euler(new Vector3(Cfg_Angle.Value, 0f, 0f));
 				newGameObject.transform.localScale = Vector3.one;
 
 				var charaSquirt = proc.gameObject.AddComponent<CharaSquirt>();

--- a/Core_BetterSquirt/CharaSquirt.cs
+++ b/Core_BetterSquirt/CharaSquirt.cs
@@ -261,6 +261,25 @@ namespace KK_BetterSquirt
 					new Keyframe(2.4f/DURATION_FULL, Random.Range(0.9f, 1.2f)),
 					new Keyframe(2.7f/DURATION_FULL, Random.Range(0.1f, 0.3f)))
 
+				//new AnimationCurve(
+				//	new Keyframe(0.1f/DURATION_FULL, Random.Range(0.75f, 0.9f)),
+				//	new Keyframe(0.4f/DURATION_FULL, Random.Range(0.75f, 0.9f)),
+				//	new Keyframe(0.5f/DURATION_FULL, 0),
+				//	new Keyframe(0.7f/DURATION_FULL, Random.Range(0.1f, 0.3f))),
+
+				//new AnimationCurve(
+				//	new Keyframe(0.2f/DURATION_FULL, Random.Range(0.2f, 0.4f)),
+				//	new Keyframe(0.4f/DURATION_FULL, Random.Range(0.2f, 0.4f))),
+
+				//new AnimationCurve(
+				//	new Keyframe(0.1f/DURATION_FULL, Random.Range(0.9f, 1.1f)),
+				//	new Keyframe(0.2f/DURATION_FULL, 0),
+				//	new Keyframe(0.5f/DURATION_FULL, 0),
+				//	new Keyframe(0.6f/DURATION_FULL, Random.Range(0.1f, 0.3f))),
+
+				//new AnimationCurve(
+				//	new Keyframe(0.3f/DURATION_FULL, Random.Range(0.6f, 0.8f)),
+				//	new Keyframe(0.5f/DURATION_FULL, Random.Range(0.2f, 0.4f)))
 			};
 
 			//Time value for each Keyframe is normalized between 0 and 1 relative to the total duration of the particle system.


### PR DESCRIPTION
In KKS both particle fields are always active, and point at 0 index female. This fixes it, allowing to run in lesbian/3P and removing extra copy of particle otherwise. Love the plugin.